### PR TITLE
環境変数の名前を元に戻した

### DIFF
--- a/app/src/app/lib/supabaseClient.ts
+++ b/app/src/app/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl: string = process.env.SUPABASE_URL!;
-const supabaseAnonKey: string = process.env.SUPABASE_ANON_KEY!;
+const supabaseUrl: string = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey: string = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
クライアントから使うときにはNEXT_PUBLICを前に付ける必要があるらしい